### PR TITLE
Refactor Travis CI configuration with adding integration tests and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,14 @@ python:
 services:
   - docker
 
-before_install:
-    - wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - "./miniconda.sh -b"
-    - export PATH=/home/travis/miniconda3/bin:$PATH
-    - conda update --yes conda
-    - sudo rm -rf /dev/shm
-    - sudo ln -s /run/shm /dev/shm
-    - docker-compose -f ./docker-compose-unit-test.yml build
 install:
-    - pip install sphinx sphinx_rtd_theme m2r sklearn pandas simplejson xgboost
-    - pip install matplotlib Cython mlxtend
-    - pip install --no-cache-dir git+https://github.com/lacava/surprise.git@master
+
+    - docker-compose -f ./docker-compose-unit-test.yml build
 script:
+    # Building Docs
+    - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate
     # Unit tests
     - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
-    # Use Sphinx to make the html docs
-    - make -C docs/ html
     # Tell GitHub not to use jekyll to compile the docs
     - touch target/ai_docs/html/.nojekyll
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ jobs:
       script:
         # Unit tests
         - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
-    - stage: deploy
-      script:
+        # Building docs
         - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate
         - sudo touch target/ai_docs/html/.nojekyll
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,33 @@ python:
 services:
   - docker
 
-install:
-    - docker-compose -f ./docker-compose-unit-test.yml build
-
-script:
-    # Building Docs
-    - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate
-    # Unit tests
-    - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
-    # Tell GitHub not to use jekyll to compile the docs
-    - sudo touch target/ai_docs/html/.nojekyll
-
-# Tell Travis CI to copy the documentation to the gh-pages branch of
-# your GitHub repository.
-deploy:
-    provider: pages
-    skip_cleanup: true
-    github_token: $GH_TOKEN  # Set in travis-ci.org dashboard, marked secure
-    on:
-        branch: master
-    local_dir: target/ai_docs/html/
+jobs:
+  include:
+    - stage: Test
+      before_install:
+        # Rebuild PennAI Base
+        - docker build ./dockers/base -t pennai/base:latest
+      install:
+        # Building Docker images
+        - docker-compose -f ./docker-compose-int-test.yml build
+      script:
+        # Unit tests
+        - docker-compose -f ./docker-compose-int-test.yml up --abort-on-container-exit --force-recreate
+    - # stage name not required, will continue to use `Test`
+      install:
+        # Building Docker images
+        - docker-compose -f ./docker-compose-unit-test.yml build
+      script:
+        # Unit tests
+        - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
+    - stage: deploy
+      script:
+        - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate
+        - sudo touch target/ai_docs/html/.nojekyll
+      deploy:
+          provider: pages
+          skip_cleanup: true
+          github_token: $GH_TOKEN  # Set in travis-ci.org dashboard, marked secure
+          on:
+              branch: master
+          local_dir: target/ai_docs/html/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ jobs:
       script:
         # Unit tests
         - docker-compose -f ./docker-compose-int-test.yml up --abort-on-container-exit --force-recreate
-    - # stage name not required, will continue to use `Test`
-      name: "Unit Tests" 
+    - # stage name not required, will continue to use 'Test'
+      name: "Unit Tests"
       install:
         # Building Docker images
         - docker-compose -f ./docker-compose-unit-test.yml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
     # Unit tests
     - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
     # Tell GitHub not to use jekyll to compile the docs
-    - touch target/ai_docs/html/.nojekyll
+    - sudo touch target/ai_docs/html/.nojekyll
 
 # Tell Travis CI to copy the documentation to the gh-pages branch of
 # your GitHub repository.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 install:
-
     - docker-compose -f ./docker-compose-unit-test.yml build
+
 script:
     # Building Docs
     - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: true
-language: python
-python:
-- '3.6'
+
 services:
   - docker
 
@@ -26,6 +24,7 @@ jobs:
         - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
         # Building docs
         - docker-compose -f ./docker-compose-doc-builder.yml up --abort-on-container-exit --force-recreate
+        # Tell GitHub not to use jekyll to compile the docs
         - sudo touch target/ai_docs/html/.nojekyll
       deploy:
           provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: true
-
+dist: xenial
 services:
   - docker
 
@@ -9,10 +9,10 @@ jobs:
       name: "Integration Tests"
       before_install:
         # Rebuild PennAI Base
-        - docker build ./dockers/base -t pennai/base:latest
+        - docker build ./dockers/base -t pennai/base:latest -m 6g
       install:
         # Building Docker images
-        - docker-compose -f ./docker-compose-int-test.yml build
+        - docker-compose -f ./docker-compose-int-test.yml build -m 6g
       script:
         # Unit tests
         - docker-compose -f ./docker-compose-int-test.yml up --abort-on-container-exit --force-recreate
@@ -20,7 +20,7 @@ jobs:
       name: "Unit Tests"
       install:
         # Building Docker images
-        - docker-compose -f ./docker-compose-unit-test.yml build
+        - docker-compose -f ./docker-compose-unit-test.yml build -m 6g
       script:
         # Unit tests
         - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: true
 language: python
 python:
 - '3.6'
+services:
+  - docker
 
 before_install:
     - wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O miniconda.sh
@@ -11,11 +13,14 @@ before_install:
     - conda update --yes conda
     - sudo rm -rf /dev/shm
     - sudo ln -s /run/shm /dev/shm
+    - docker-compose -f ./docker-compose-unit-test.yml build
 install:
-    - pip install sphinx sphinx_rtd_theme m2r sklearn pandas simplejson xgboost 
+    - pip install sphinx sphinx_rtd_theme m2r sklearn pandas simplejson xgboost
     - pip install matplotlib Cython mlxtend
     - pip install --no-cache-dir git+https://github.com/lacava/surprise.git@master
 script:
+    # Unit tests
+    - docker-compose -f ./docker-compose-unit-test.yml up --abort-on-container-exit --force-recreate
     # Use Sphinx to make the html docs
     - make -C docs/ html
     # Tell GitHub not to use jekyll to compile the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 jobs:
   include:
     - stage: Test
+      name: "Integration Tests"
       before_install:
         # Rebuild PennAI Base
         - docker build ./dockers/base -t pennai/base:latest
@@ -16,6 +17,7 @@ jobs:
         # Unit tests
         - docker-compose -f ./docker-compose-int-test.yml up --abort-on-container-exit --force-recreate
     - # stage name not required, will continue to use `Test`
+      name: "Unit Tests" 
       install:
         # Building Docker images
         - docker-compose -f ./docker-compose-unit-test.yml build

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -47,13 +47,13 @@ Learn
 =====
 
 This is the API for building ML models.
-PennAI uses scikit-learn to achieve this. 
+PennAI uses scikit-learn to achieve this.
 
 ==
 IO
 ==
 
-These methods control data flow from the server to and from sklearn models. 
+These methods control data flow from the server to and from sklearn models.
 
 .. autoclass:: machine.learn.io_utils.Experiment
     :members:
@@ -70,7 +70,7 @@ These methods control data flow from the server to and from sklearn models.
 
 .. autofunction:: machine.learn.io_utils.bool_type
 
-.. autofunction:: machine.learn.io_utils.str_or_none
+.. autofunction:: machine.learn.io_utils.none
 
 .. autofunction:: machine.learn.io_utils.get_type
 
@@ -79,7 +79,7 @@ These methods control data flow from the server to and from sklearn models.
 Scikit-learn Utils
 =============
 
-These methods generate sklearn models and evaluate them. 
+These methods generate sklearn models and evaluate them.
 
 .. autofunction:: machine.learn.skl_utils.balanced_accuracy
 
@@ -104,4 +104,3 @@ These methods generate sklearn models and evaluate them.
 .. autofunction:: machine.learn.skl_utils.export_model
 
 .. autofunction:: machine.learn.skl_utils.generate_export_codes
-


### PR DESCRIPTION
- This PR uses docker for integration tests and unit tests as we did in our Jenkins server.
- Both tests run in parallel in Travis CI
- Deployment of docs is in unit tests' stage because they use the same docker image
 