### PR TITLE
SHAP Summary Plot

### DIFF
--- a/docker/lab/files/requirements.txt
+++ b/docker/lab/files/requirements.txt
@@ -6,3 +6,4 @@ cython==0.29.2
 xgboost==0.82
 simplejson==3.16.0
 requests==2.22.0
+shap==0.34.0

--- a/docker/machine/files/requirements.txt
+++ b/docker/machine/files/requirements.txt
@@ -7,3 +7,4 @@ mlxtend==0.16.0
 pydot==1.4.1
 requests==2.22.0
 xgboost==0.90
+shap==0.34.0

--- a/lab/webapp/src/components/InvertedCardWithDropdown/index.jsx
+++ b/lab/webapp/src/components/InvertedCardWithDropdown/index.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Dropdown, Grid, Segment, Header, Popup, Button } from 'semantic-ui-react';
+
+function InvertedCardWithDropdown({ 
+  header,
+  headericon, 
+  tooltip, 
+  options, 
+  placeholder, 
+  selectoption, 
+  dropdownoptions, 
+  onoptionchange,
+  content, 
+  footer 
+}) {
+  return (
+    <div className="inverted-card">
+      <Segment inverted attached="top">
+      <Header inverted size="medium">
+          {header}
+          {headericon &&
+            <span className="float-right">
+              {headericon}
+            </span>
+          }
+        </Header>
+        {tooltip &&
+          <span className="float-right">
+            <Popup
+              trigger={<Button circular class="small button" icon="info" />}
+              content={tooltip}
+            />
+          </span>  
+        }
+        {options &&
+          <span className="float-right">
+            {options}
+          </span>
+        }
+      </Segment>
+      <Segment inverted attached="bottom">
+        <span>
+          <Header inverted size="small" content={
+            <Grid>
+              <Grid.Column width={5} style={
+                {verticalAlign: 'center',
+                textAlign: 'center',
+                lineHeight: '30px'}}>
+                Class Name
+              </Grid.Column> 
+              <Grid.Column width={11}>
+                <Dropdown
+                    style={{fontSize: '12px'}}
+                    placeholder={placeholder}
+                    fluid
+                    search
+                    selection
+                    onChange={onoptionchange}
+                    value={selectoption}
+                    options={dropdownoptions}
+                  />
+              </Grid.Column>
+            </Grid>
+          } />
+          {content}
+        </span>
+      </Segment>
+      {footer &&
+        <span>{footer}</span>
+      }
+    </div>
+  );
+}
+
+export default InvertedCardWithDropdown;

--- a/lab/webapp/src/components/Results/components/ShapSummaryCurve/index.jsx
+++ b/lab/webapp/src/components/Results/components/ShapSummaryCurve/index.jsx
@@ -5,7 +5,7 @@ import InvertedCardWithDropdown from '../../../InvertedCardWithDropdown';
 import InvertedCard from '../../../InvertedCard';
 import { Popup, Icon, Image, Loader } from 'semantic-ui-react';
 
-class SummaryCurve extends Component {
+class ShapSummaryCurve extends Component {
   constructor(props) {
     super(props);
     this.handle_class_change = this.handle_class_change.bind(this);
@@ -13,7 +13,7 @@ class SummaryCurve extends Component {
   }
 
   componentDidMount() {
-    const { fileDict } = this.props;
+    const { fileDict, shap_explainer, shap_num_samples } = this.props;
 
     if(!(Object.keys(fileDict).length === 0)) {
       const class_name = Object.keys(fileDict)[0];
@@ -41,7 +41,7 @@ class SummaryCurve extends Component {
   }
 
   handle_class_change(e, { value }) {
-    const { fileDict } = this.props;
+    const { fileDict, shap_explainer, shap_num_samples } = this.props;
     const file = fileDict[value];
 
     fetch(`/api/v1/files/${file._id}`)
@@ -58,13 +58,30 @@ class SummaryCurve extends Component {
   }
 
   render() {
-    const { fileDict } = this.props;
+    const { fileDict, shap_explainer, shap_num_samples } = this.props;
     const { image_url, class_name, class_options } = this.state;
-    const desc = "Summary plot sorts features by their impact. It uses SHAP values to explain the output of ML models.";
+    const desc = "SHAP feature importance plot that shows the positive and negative relationships between samples and features with this ML model.  The plot sorts features by the sum of SHAP value magnitudes.";
+    const shap_url = "https://github.com/slundberg/shap"
     let headericon = (
       <Popup
+        on="click"
         position="top center"
-        content={desc}
+        content={
+          <div className="content">
+            <p>{desc}</p>
+            { (shap_explainer && shap_num_samples>=0) &&
+              <p>The plot below uses the SHAP <strong>{shap_explainer}</strong> with <strong>{shap_num_samples}</strong> randomly selected samples.</p>
+            }
+
+            { (shap_explainer && shap_num_samples<0) &&
+              <p>The plot below uses the <strong>{shap_explainer}</strong>.</p>
+            }
+
+            {shap_url &&
+              <a href={shap_url} target="_blank"><strong>Read more here <Icon name="angle double right" /></strong></a>
+            }
+          </div>
+        }
         trigger={
           <Icon
             name="info circle"
@@ -114,4 +131,4 @@ class SummaryCurve extends Component {
   }
 }
 
-export default SummaryCurve;
+export default ShapSummaryCurve;

--- a/lab/webapp/src/components/Results/components/SummaryCurve/index.jsx
+++ b/lab/webapp/src/components/Results/components/SummaryCurve/index.jsx
@@ -1,0 +1,117 @@
+require('es6-promise').polyfill();
+import fetch from 'isomorphic-fetch';
+import React, { Component } from 'react';
+import InvertedCardWithDropdown from '../../../InvertedCardWithDropdown';
+import InvertedCard from '../../../InvertedCard';
+import { Popup, Icon, Image, Loader } from 'semantic-ui-react';
+
+class SummaryCurve extends Component {
+  constructor(props) {
+    super(props);
+    this.handle_class_change = this.handle_class_change.bind(this);
+    this.state = { image_url: null, class_name: null, class_options: null };
+  }
+
+  componentDidMount() {
+    const { fileDict } = this.props;
+
+    if(!(Object.keys(fileDict).length === 0)) {
+      const class_name = Object.keys(fileDict)[0];
+      const file = fileDict[class_name];
+
+      fetch(`/api/v1/files/${file._id}`)
+        .then(response => {
+          if(response.status >= 400) {
+            throw new Error(`${response.status}: ${response.statusText}`);
+          }  
+          return response.blob();
+        })
+        .then(blob => this.setState({
+          image_url: URL.createObjectURL(blob), 
+          class_name: class_name,
+        }));
+
+      // Populate dropdown list values
+      let class_options = [];
+      Object.keys(fileDict).forEach(function(class_name) {
+        class_options.push({key: class_name, value: class_name, text: class_name})
+      });
+      this.setState({class_options});
+    }
+  }
+
+  handle_class_change(e, { value }) {
+    const { fileDict } = this.props;
+    const file = fileDict[value];
+
+    fetch(`/api/v1/files/${file._id}`)
+        .then(response => {
+          if(response.status >= 400) {
+            throw new Error(`${response.status}: ${response.statusText}`);
+          }  
+          return response.blob();
+        })
+        .then(blob => this.setState({
+          image_url: URL.createObjectURL(blob), 
+          class_name: value,
+        }));
+  }
+
+  render() {
+    const { fileDict } = this.props;
+    const { image_url, class_name, class_options } = this.state;
+    const desc = "Summary plot sorts features by their impact. It uses SHAP values to explain the output of ML models.";
+    let headericon = (
+      <Popup
+        position="top center"
+        content={desc}
+        trigger={
+          <Icon
+            name="info circle"
+            className="info-icon float-right"
+          />
+        }
+      />
+    );
+
+    if(Object.keys(fileDict).length === 0) {
+      return (
+        <InvertedCard
+          header="SHAP Summary Plot"
+          content="Summary curve not generated for this model."
+          headericon={headericon}
+        />
+      );
+    }
+
+    if(!image_url) {
+      return (
+        <Loader active inverted inline="centered" content="Retrieving Summary curve..." />
+      );
+    }
+    
+    if (Object.keys(fileDict).length === 1) {
+      return (
+        <InvertedCard
+          header="SHAP Summary Plot"
+          content={<Image src={image_url} />}
+          headericon={headericon}
+        />
+      );
+    }
+
+    return (
+        <InvertedCardWithDropdown
+          header="SHAP Summary Plot"
+          placeholder="Select Output Class"
+          selectoption={class_name}
+          dropdownoptions={class_options}
+          onoptionchange={this.handle_class_change}
+          content={<Image src={image_url} />}
+          headericon={headericon}
+        />
+    );
+  }
+}
+
+export default SummaryCurve;

--- a/lab/webapp/src/components/Results/index.jsx
+++ b/lab/webapp/src/components/Results/index.jsx
@@ -8,7 +8,7 @@ import RunDetails from './components/RunDetails'
 import MSEMAEDetails from './components/MSEMAEDetails';;
 import ConfusionMatrix from './components/ConfusionMatrix';
 import ROCCurve from './components/ROCCurve';
-import SummaryCurve from './components/SummaryCurve';
+import ShapSummaryCurve from './components/ShapSummaryCurve';
 import ImportanceScore from './components/ImportanceScore';
 import RegFigure from './components/RegFigure';
 import Score from './components/Score';
@@ -84,8 +84,8 @@ class Results extends Component {
     console.log(experiment.data.prediction_type)
     // --- get lists of scores ---
     if(experiment.data.prediction_type == "classification") { // classification
-      let confusionMatrix, rocCurve, importanceScore;
-      let summaryCurveDict = {};
+      let confusionMatrix, rocCurve, importanceScore, shap_explainer, shap_num_samples;
+      let shapSummaryCurveDict = {};
       experiment.data.experiment_files.forEach(file => {
         const filename = file.filename;
         if(filename.includes('confusion_matrix')) {
@@ -96,7 +96,9 @@ class Results extends Component {
           importanceScore = file;
         } else if(filename.includes('shap_summary_curve')) {
           let class_name = filename.split('_').slice(-2,-1);
-          summaryCurveDict[class_name] = file;
+          shapSummaryCurveDict[class_name] = file;
+          shap_explainer=experiment.data.shap_explainer;
+          shap_num_samples=experiment.data.shap_num_samples;
         }
       });
       // balanced accuracy
@@ -138,7 +140,10 @@ class Results extends Component {
               <Grid.Column>
                 <ConfusionMatrix file={confusionMatrix} />
                 <ROCCurve file={rocCurve} />
-                <SummaryCurve fileDict={summaryCurveDict} />
+                <ShapSummaryCurve 
+                  fileDict={shapSummaryCurveDict} 
+                  shap_explainer={shap_explainer}
+                  shap_num_samples={shap_num_samples} />
               </Grid.Column>
               <Grid.Column>
                 <Score

--- a/lab/webapp/src/components/Results/index.jsx
+++ b/lab/webapp/src/components/Results/index.jsx
@@ -8,6 +8,7 @@ import RunDetails from './components/RunDetails'
 import MSEMAEDetails from './components/MSEMAEDetails';;
 import ConfusionMatrix from './components/ConfusionMatrix';
 import ROCCurve from './components/ROCCurve';
+import SummaryCurve from './components/SummaryCurve';
 import ImportanceScore from './components/ImportanceScore';
 import RegFigure from './components/RegFigure';
 import Score from './components/Score';
@@ -84,6 +85,7 @@ class Results extends Component {
     // --- get lists of scores ---
     if(experiment.data.prediction_type == "classification") { // classification
       let confusionMatrix, rocCurve, importanceScore;
+      let summaryCurveDict = {};
       experiment.data.experiment_files.forEach(file => {
         const filename = file.filename;
         if(filename.includes('confusion_matrix')) {
@@ -92,6 +94,9 @@ class Results extends Component {
           rocCurve = file;
         } else if(filename.includes('imp_score')) {
           importanceScore = file;
+        } else if(filename.includes('shap_summary_curve')) {
+          let class_name = filename.split('_').slice(-2,-1);
+          summaryCurveDict[class_name] = file;
         }
       });
       // balanced accuracy
@@ -133,6 +138,7 @@ class Results extends Component {
               <Grid.Column>
                 <ConfusionMatrix file={confusionMatrix} />
                 <ROCCurve file={rocCurve} />
+                <SummaryCurve fileDict={summaryCurveDict} />
               </Grid.Column>
               <Grid.Column>
                 <Score

--- a/machine/test/learn_tests.py
+++ b/machine/test/learn_tests.py
@@ -476,7 +476,18 @@ class APITESTCLASS(unittest.TestCase):
             # test pickle file
             pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
             assert os.path.isfile(pickle_file)
-
+            # test SHAP summary files are generated except for SVC, LinearSVC
+            if algorithm_name == 'SVC' or algorithm_name == 'LinearSVC':
+                assert not os.path.isfile('{}/shap_summary_curve{}_0_.png'.format(outdir, _id))
+            elif algorithm_name == 'GradientBoostingClassifier':
+                # GradientBoostingClassifier for Binary Classification using Tree Explainer
+                assert os.path.isfile('{}/shap_summary_curve{}_0_.png'.format(outdir, _id))
+                assert not os.path.isfile('{}/shap_summary_curve{}_1_.png'.format(outdir, _id))
+            else:
+                for class_id in range(2):
+                    shap_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+                    assert os.path.isfile(shap_file)
+            
             # test reloaded model is the same
             pickle_model = joblib.load(pickle_file)
             load_clf = pickle_model['model']
@@ -528,6 +539,11 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/confusion_matrix_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/imp_score_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
+        # test SHAP summary files
+        # GradientBoostingClassifier for multiclass case using Kernel Explainer
+        for class_id in range(3):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)       
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -585,6 +601,10 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/confusion_matrix_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/imp_score_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
+        # test SHAP summary files
+        for class_id in range(3):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -640,6 +660,10 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/confusion_matrix_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/imp_score_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
+        # test SHAP summary files
+        for class_id in range(2):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -678,6 +702,10 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/confusion_matrix_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/imp_score_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
+        # test SHAP summary files
+        for class_id in range(2):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)      
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -717,6 +745,10 @@ class APITESTCLASS(unittest.TestCase):
         assert not os.path.isfile('{}/roc_curve_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/imp_score_{}.png'.format(outdir, _id))
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
+        # test SHAP summary files
+        for class_id in range(3):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -787,6 +819,11 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
         assert os.path.isfile(
             '{}/grid_search_results_{}.csv'.format(outdir, _id))
+        # test SHAP summary files
+        # GradientBoostingClassifier for multiclass case using Kernel Explainer
+        for class_id in range(3):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)
@@ -855,6 +892,10 @@ class APITESTCLASS(unittest.TestCase):
         assert os.path.isfile('{}/scripts_reproduce_{}.py'.format(outdir, _id))
         assert os.path.isfile(
             '{}/grid_search_results_{}.csv'.format(outdir, _id))
+        # test SHAP summary files
+        for class_id in range(2):
+            summary_file = '{}/shap_summary_curve{}_{}_.png'.format(outdir, _id, class_id)
+            assert os.path.isfile(summary_file)
         # test pickle file
         pickle_file = '{}/model_{}.pkl'.format(outdir, _id)
         assert os.path.isfile(pickle_file)

--- a/tests/unit/files/requirements.txt
+++ b/tests/unit/files/requirements.txt
@@ -16,3 +16,4 @@ parameterized==0.7.0
 m2r==0.2.1
 sphinx-rtd-theme==0.4.3
 requests==2.22.0
+shap==0.34.0


### PR DESCRIPTION
Adding implementation to visualize SHAP Summary plots for Classification models

- Currently plot images for all classes are created and stored.
- Kernel based explainers are slow, so random sampling of 50 features is performed (updated as 200 was working slower on the recent branch with regression)
- Summary Curves with multiple classes are displayed using a modified form of InvertedCard, named InvertedCardWithDropdown