### PR TITLE
webapp - add webpack sourcemapping to development mode builds.

### DIFF
--- a/lab/webapp/package-lock.json
+++ b/lab/webapp/package-lock.json
@@ -20186,6 +20186,15 @@
         }
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/lab/webapp/package.json
+++ b/lab/webapp/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "your friendly machine learning assistant",
   "scripts": {
-    "build": "webpack",
-    "build-dev": "webpack --watch",
+    "build": "webpack --mode=production",
+    "build-dev": "webpack --watch --mode=development",
     "test": "jest"
   },
   "repository": {
@@ -46,9 +46,12 @@
     "@babel/preset-react": "^7.9.4",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.1.0",
+    "clean-webpack-plugin": "^3.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-15": "^1.4.1",
     "fetch-mock": "^7.7.3",
+    "html-webpack-plugin": "^3.2.0",
+    "html-webpack-template": "^6.2.0",
     "jest": "^24.9.0",
     "jest-fetch-mock": "^2.1.2",
     "jest-html-reporter": "^2.8.2",
@@ -58,12 +61,10 @@
     "react-test-renderer": "^15.6.2",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.4",
+    "typescript": "^3.8.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
-    "clean-webpack-plugin": "^3.0.0",
-    "html-webpack-plugin": "^3.2.0",
-    "html-webpack-template": "^6.2.0",
-    "typescript": "^3.8.3"
+    "webpack-merge": "^4.2.2"
   },
   "jest": {
     "transform": {

--- a/lab/webapp/webpack.config.js
+++ b/lab/webapp/webpack.config.js
@@ -3,7 +3,19 @@ var webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
-module.exports = {
+//Use a function here so we can check the value of the 'mode' parameter
+//https://webpack.js.org/configuration/mode/
+module.exports = (env, argv) => {
+
+  if (argv.mode === 'development') {
+    console.log('webpack.config.js: mode === development');
+    config.devtool = 'eval-source-map';
+  }
+
+  return config;
+}
+
+var config = {
   entry: [
     './src/index.jsx'
   ],


### PR DESCRIPTION
'npm run' is now called with --mode option to specify 'development' vs
'production'. 

In development build, webpack sourcemapping is enabled.

View sourcemaps in browser dev tools. Tested successfully with
breakpoint setting in source files in chrome dev tools.

Unity & int. tests passed locally and on Jenkins

Partially resolves #258