### PR TITLE
Unit testing - add env var-based options for managing which run

### DIFF
--- a/config/unit-test-js-only.env
+++ b/config/unit-test-js-only.env
@@ -1,0 +1,5 @@
+# Optional env file to include for running only js unit tests in lab
+# Gets picked up in tests/unit/unit_test_runner.sh
+# e.g. docker-compose --env-file ./config/unit-test-js-only.env -f .\docker-compose-unit-test.yml up --abort-on-container-exit
+
+PENNAI_UNIT_TESTS_JS_ONLY=1

--- a/config/unit-test-py-only.env
+++ b/config/unit-test-py-only.env
@@ -1,0 +1,5 @@
+# Optional env file to include for running only python unit tests in lab
+# Gets picked up in tests/unit/unit_test_runner.sh
+# e.g. docker-compose --env-file ./config/unit-test-py-only.env -f .\docker-compose-unit-test.yml up --abort-on-container-exit
+
+PENNAI_UNIT_TESTS_PY_ONLY=1

--- a/docker-compose-unit-test.yml
+++ b/docker-compose-unit-test.yml
@@ -6,10 +6,12 @@ services:
       context: .
       dockerfile: tests/unit/Dockerfile
     working_dir: /appsrc
-    command: bash -c "dos2unix tests/unit/unit_test_runner.sh && sh tests/unit/unit_test_runner.sh"
+    command: bash -c "dos2unix tests/unit/unit_test_runner.sh && export PENNAI_UNIT_TESTS_JS_ONLY=$PENNAI_UNIT_TESTS_JS_ONLY && export PENNAI_UNIT_TESTS_PY_ONLY=$PENNAI_UNIT_TESTS_PY_ONLY && sh tests/unit/unit_test_runner.sh"
     tty: true
     stdin_open: true
     volumes:
       - "./:/appsrc"
       - "/appsrc/lab/webapp/node_modules"
       - "/appsrc/lab/node_modules"
+      
+      

--- a/tests/unit/unit_test_runner.sh
+++ b/tests/unit/unit_test_runner.sh
@@ -1,7 +1,37 @@
 #!/bin/bash
 
+# NOTE
+# To run only the python tests (py_tests.sh) or only the web/javascript tests
+# (js_tests.sh), set the appropriate env var, as used below.
+# With docker-compose, use the --env-file param and pass either of
+# config/unit-test-js-only.env, or
+# config/unit-test-py-only.env
+
 dos2unix /appsrc/tests/unit/py_tests.sh
 dos2unix /appsrc/tests/unit/js_tests.sh
 
-. /appsrc/tests/unit/py_tests.sh
-. /appsrc/tests/unit/js_tests.sh
+# initialize
+pyres=0
+jsres=0
+
+# run via sh to avoid permissions problem
+if [ -z "${PENNAI_UNIT_TESTS_JS_ONLY}" ]; then
+  sh /appsrc/tests/unit/py_tests.sh
+  pyres=$?
+  # echo "==== py_tests unit tests result "$pyres
+else
+  echo "$0 - skipped py_tests"
+fi
+
+# run via sh to avoid permissions problem
+if [ -z "${PENNAI_UNIT_TESTS_PY_ONLY}" ]; then
+  sh /appsrc/tests/unit/js_tests.sh
+  jsres=$?
+  # echo "==== js_tests unit tests result "$jsres
+else
+  echo "$0 - skipped js_tests"
+fi
+
+# exit with code 1 if either test fails
+# If we don't exit with a non-zero value, github actions won't catch the error
+if [ $pyres -eq 0 -a $jsres -eq 0 ]; then exit 0; else exit 1; fi


### PR DESCRIPTION
Can now run only python unit tests, only javascript/web unit tests, or
both, using docker-compose and unit-test yml file and new env files.

See notes in `config/unit-test-js-only.env`

After this has been approved, I'll update the developer documentation.